### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## What does this PR do?
+
+<!-- Brief description of the change and motivation -->
+
+Fixes #
+
+## How was it tested?
+
+<!-- Commands run, manual steps, or screenshots -->
+
+## Checklist
+
+- [ ] `pnpm test` passes
+- [ ] `pnpm typecheck` passes
+
+<!--
+If applicable:
+- [ ] Breaking change (describe migration below)
+- [ ] i18n strings added to all catalogs (en, ko, ja)
+-->


### PR DESCRIPTION
## What does this PR do?

Add a PR template (`.github/pull_request_template.md`) to standardize pull request descriptions.

## Why

No PR template existed. Researched 13 major OSS projects (React, Angular, Bun, Vite, Deno, etc.) and picked a minimal structure suited for a small CLI project: What/How tested/Checklist.

## How was it tested?

N/A — documentation-only change.

## Checklist

- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes