### PR TITLE
feat: add animated spinner for long-running CLI operations

### DIFF
--- a/bin/arbors.ts
+++ b/bin/arbors.ts
@@ -16,6 +16,7 @@ import { loadMessages } from "../src/i18n/index";
 import { getWorktrees, registerProject, registerWorktree, unregisterWorktree } from "../src/project/registry";
 import { runSetup } from "../src/project/setup";
 import { createAdapter } from "../src/runtime/index";
+import { withSpinner } from "../src/tui/withSpinner";
 
 const parseArgs = (argv: string[]) => {
   const args = argv.slice(2);
@@ -127,22 +128,25 @@ const main = async () => {
 
       if (flags.create) {
         // arbors add -c <branch> [--base main]
-        console.log(chalk.gray(msg.creating));
-        worktreePath = await createWorktree(adapter, name, config.worktreeDir, flags.base);
+        worktreePath = await withSpinner(msg.creating, () =>
+          createWorktree(adapter, name, config.worktreeDir, flags.base),
+        );
         created = true;
         newBranch = true;
         console.log(chalk.green(`✓ ${msg.created}: ${worktreePath}`));
         console.log(chalk.gray(`  Branch: ${name} (from ${flags.base ?? "default"})`));
       } else if (await branchExists(adapter, name)) {
-        console.log(chalk.gray(`Checking out ${name}...`));
-        const result = await checkoutWorktree(adapter, name, config.worktreeDir);
+        const result = await withSpinner(`Checking out ${name}...`, () =>
+          checkoutWorktree(adapter, name, config.worktreeDir),
+        );
         worktreePath = result.path;
         created = result.created;
         console.log(chalk.green(`✓ ${msg.created}: ${worktreePath}`));
         console.log(chalk.gray(`  Branch: ${name}`));
       } else if (await remoteBranchExists(adapter, name)) {
-        console.log(chalk.gray(`Fetching ${name} from origin...`));
-        const result = await checkoutRemoteWorktree(adapter, name, config.worktreeDir);
+        const result = await withSpinner(`Fetching ${name} from origin...`, () =>
+          checkoutRemoteWorktree(adapter, name, config.worktreeDir),
+        );
         worktreePath = result.path;
         created = result.created;
         newBranch = result.created;
@@ -158,13 +162,15 @@ const main = async () => {
 
       try {
         console.log();
-        console.log(chalk.gray(msg.copying));
-        const copied = await copyIgnoredFiles(adapter, worktreePath, config.excludeFromCopy);
+        const copied = await withSpinner(msg.copying, () =>
+          copyIgnoredFiles(adapter, worktreePath, config.excludeFromCopy),
+        );
         console.log(chalk.green(`✓ ${msg.copied} (${copied.length} files)`));
 
         console.log();
-        console.log(chalk.gray(msg.installing));
-        await runSetup(adapter, worktreePath, config.packageManager);
+        await withSpinner(msg.installing, () =>
+          runSetup(adapter, worktreePath, config.packageManager),
+        );
         console.log(chalk.green(`✓ ${msg.installed}`));
 
         const repoRoot = await getMainRepoRoot(adapter);
@@ -256,10 +262,11 @@ const main = async () => {
           process.exitCode = 1;
           return;
         }
-        console.log(chalk.gray(msg.removing));
       }
-      await removeWorktree(adapter, target.path, target.branch);
-      await unregisterWorktree(adapter, target.path);
+      await withSpinner(msg.removing, async () => {
+        await removeWorktree(adapter, target.path, target.branch);
+        await unregisterWorktree(adapter, target.path);
+      });
       console.log(chalk.green(`✓ ${msg.removed}: ${name}`));
       break;
     }

--- a/src/tui/withSpinner.tsx
+++ b/src/tui/withSpinner.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { Text, render } from "ink";
+
+const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const INTERVAL = 80;
+
+const Spinner = ({ label }: { label: string }) => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % FRAMES.length);
+    }, INTERVAL);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <Text>
+      <Text color="cyan">{FRAMES[index]}</Text>
+      <Text dimColor> {label}</Text>
+    </Text>
+  );
+};
+
+export async function withSpinner<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  if (!process.stdout.isTTY) {
+    console.log(label);
+    return fn();
+  }
+
+  const inst = render(<Spinner label={label} />, { patchConsole: false });
+
+  try {
+    return await fn();
+  } finally {
+    inst.clear();
+    inst.unmount();
+  }
+}

--- a/tests/withSpinner.test.tsx
+++ b/tests/withSpinner.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockClear = vi.fn();
+const mockUnmount = vi.fn();
+
+vi.mock("ink", () => ({
+  render: vi.fn(() => ({ clear: mockClear, unmount: mockUnmount })),
+  Text: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { withSpinner } from "../src/tui/withSpinner";
+
+describe("withSpinner", () => {
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    originalIsTTY = process.stdout.isTTY;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+  });
+
+  describe("non-TTY", () => {
+    beforeEach(() => {
+      Object.defineProperty(process.stdout, "isTTY", { value: false, writable: true });
+    });
+
+    it("should return fn result", async () => {
+      const result = await withSpinner("loading...", async () => 42);
+      expect(result).toBe(42);
+    });
+
+    it("should propagate fn errors", async () => {
+      await expect(
+        withSpinner("loading...", async () => {
+          throw new Error("fail");
+        }),
+      ).rejects.toThrow("fail");
+    });
+
+    it("should log label to console", async () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      await withSpinner("loading...", async () => "ok");
+      expect(spy).toHaveBeenCalledWith("loading...");
+      spy.mockRestore();
+    });
+
+    it("should not call ink render", async () => {
+      const { render } = await import("ink");
+      await withSpinner("loading...", async () => "ok");
+      expect(render).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("TTY", () => {
+    beforeEach(() => {
+      Object.defineProperty(process.stdout, "isTTY", { value: true, writable: true });
+    });
+
+    it("should return fn result", async () => {
+      const result = await withSpinner("loading...", async () => "done");
+      expect(result).toBe("done");
+    });
+
+    it("should call clear and unmount on success", async () => {
+      await withSpinner("loading...", async () => "ok");
+      expect(mockClear).toHaveBeenCalledOnce();
+      expect(mockUnmount).toHaveBeenCalledOnce();
+    });
+
+    it("should call clear and unmount on error", async () => {
+      await withSpinner("loading...", async () => {
+        throw new Error("boom");
+      }).catch(() => {});
+
+      expect(mockClear).toHaveBeenCalledOnce();
+      expect(mockUnmount).toHaveBeenCalledOnce();
+    });
+
+    it("should propagate fn errors", async () => {
+      await expect(
+        withSpinner("loading...", async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+    });
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,6 +8,16 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   noExternal: [/.*/],
+  esbuildPlugins: [
+    {
+      name: "external-devtools",
+      setup(build) {
+        build.onResolve({ filter: /^react-devtools-core$/ }, () => ({
+          external: true,
+        }));
+      },
+    },
+  ],
   banner: {
     js: "#!/usr/bin/env node",
   },


### PR DESCRIPTION
## Summary

Closes #12

- `withSpinner(label, fn)` wraps async operations with an Ink-based braille spinner
- Applied to all long-running operations: git fetch, worktree add/remove, file copy, dependency install
- Non-TTY environments fall back to static `console.log`
- esbuild plugin added to externalize `react-devtools-core` for Ink bundling compatibility

## Changes

| File | Change |
|------|--------|
| `src/tui/withSpinner.tsx` | New — Spinner component + async wrapper (39 lines) |
| `bin/arbors.ts` | Replace 6 static `console.log` + `await` pairs with `withSpinner` calls |
| `tsup.config.ts` | Add esbuild plugin to externalize `react-devtools-core` |
| `tests/withSpinner.test.tsx` | New — 8 tests covering TTY/non-TTY paths |

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 83/83 tests pass (8 new)
- [x] `pnpm build` succeeds
- [x] `pnpm lint` — 0 errors