### PR TITLE
fix: inject createRequire shim to support CJS dynamic requires in ESM bundle

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
     },
   ],
   banner: {
-    js: "#!/usr/bin/env node",
+    js: [
+      "#!/usr/bin/env node",
+      'import { createRequire as __arbors_createRequire } from "node:module";',
+      "var require = __arbors_createRequire(import.meta.url);",
+    ].join("\n"),
   },
 });


### PR DESCRIPTION
## Summary

- `noExternal: [/.*/]` bundles CJS deps like `signal-exit@3.0.7` (from `ink`) which call `require("assert")`
- ESM output has no native `require`, causing `Dynamic require of "assert" is not supported` at runtime
- Injects `createRequire` via banner so the `__require` shim resolves Node builtins correctly

Closes #15

## Test plan

- [x] `pnpm build` succeeds
- [x] `arbors list` runs without error
- [x] All 90 tests pass